### PR TITLE
Updates for SLES SP4 samtools / augustus

### DIFF
--- a/sles11sp4/augustus.cyg
+++ b/sles11sp4/augustus.cyg
@@ -15,7 +15,7 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
 
 # tool pre-requisites modules needed to install this new tool/package
-MAALI_TOOL_PREREQ="boost/1.49.0 bamtools/2.4.0 samtools/0.1.19"
+MAALI_TOOL_PREREQ="boost/1.49.0 bamtools/2.4.0 samtools/0.1.19 htslib/1.2.1"
 
 # tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
 MAALI_TOOL_BUILD_PREREQ=""
@@ -32,12 +32,18 @@ MAALI_MODULE_SET_AUGUSTUS_CONFIG_PATH='$MAALI_APP_HOME/config'
 
 function maali_build {
   cd $MAALI_BUILD_DIR
+  
+  #Get the version of samtools on the prereq module which we need later on
+  SAMTOOL_PREREQ_VER=`echo $MAALI_SAMTOOLS_HOME | rev | cut -d "/" -f 1 | rev`
 
-  # requires samtools/0.1.19 so should be already downloaded
-  if [ -f "$MAALI_SRC/samtools-0.1.19.tar.bz2" ]; then
-    maali_run "tar jxf $MAALI_SRC/samtools-0.1.19.tar.bz2"
+  # requires samtools/XXX ie 0.1.19 so should be already downloaded
+
+  if [ -d "${MAALI_SAMTOOLS_HOME}/src" ]; then
+    # You need the existing SAMTOOLS src / build installed to compiled the auxtools
+    cd $MAALI_BUILD_DIR
+    maali_run "tar jxvf $MAALI_SRC/samtools-${SAMTOOL_PREREQ_VER}.tar.bz2"
   else
-    echo "Please compile samtools 0.1.19"
+    echo "Please compile Samtools ${SAMTOOL_PREREQ_VER}" 
     exit
   fi
 
@@ -122,14 +128,33 @@ function maali_build {
     fi
   done
 
-  cd auxprogs/checkTargetSortedness
+  #Fix aux tools bamwig
+  cd auxprogs/bam2wig
+  cp Makefile Makefile.backup
 
+  # 3.2.x Specific Templates fix
+  #SAMTOOLS refers to the build area where SAMTOOLS was built
+  sed -i -e "s^SAMTOOLS=\$(TOOLDIR)/samtools^SAMTOOLS=$MAALI_SAMTOOLS_HOME/src^g" Makefile
+  sed -i -e "s^LIBS=\$(SAMTOOLS)/libbam.a \$(HTSLIB)/libhts.a -lcurses -lm -lz -lpthread^LIBS=$MAALI_SAMTOOLS_HOME/lib/libbam.a $MAALI_HTSLIB_HOME/lib/libhts.a -lncurses -lm -lz -lpthread^g" Makefile
+
+  #3.0.x Specific Templates fix
+  sed -i -e "s^SAMTOOLS=/fs1.cm/katharina/tools/samtools/^SAMTOOLS=$MAALI_SAMTOOLS_HOME/src^g" Makefile 
+  sed -i -e "s^LIBS=\$(SAMTOOLS)/libbam.a -lcurses -lm -lz -lpthread^LIBS=$MAALI_SAMTOOLS_HOME/lib/libbam.a -lncurses -lm -lz -lpthread^g" Makefile 
+
+  #They have a precompiled bam2wig binary prepackaged which is broken
+  maali_run "make clean"
+  maali_run "make"
+  maali_run "install -m 755 bam2wig $MAALI_INSTALL_DIR/bin/"
+  cd ../..
+
+  #Fix aux tools checkTargetSortedness 
+  cd auxprogs/checkTargetSortedness
   sed -i -e 's;INCLUDES=-I$(SAMTOOLS) -I.;INCLUDES=-I'"$BAM_ROOT"'/include/bam -I.;' Makefile
   sed -i -e 's;LIBS=$(SAMTOOLS)/libbam.a;LIBS='"$BAM_ROOT"'/lib/libbam.a;' Makefile
   sed -i -e's/-lcurses/-lncurses/g' Makefile
 
-  # needs the source for samtools
-  cp $MAALI_BUILD_DIR/samtools-0.1.19/bam_index.c .
+  # needs the source for samtools ie 0.1.19
+  cp $MAALI_BUILD_DIR/samtools-${SAMTOOL_PREREQ_VER}/bam_index.c .
 
   maali_run "make"
   maali_run "install -m 755 checkTargetSortedness $MAALI_INSTALL_DIR/bin/"

--- a/sles11sp4/samtools.cyg
+++ b/sles11sp4/samtools.cyg
@@ -32,8 +32,26 @@ MAALI_TOOL_TYPE="bio-apps"
 
 # tool pre-requisites modules needed to install this new tool/package
 if [[ $(echo "if (${MAALI_TOOL_MAJOR_VERSION} >= 1) 1 else 0" | bc) -eq 1 ]]; then
-MAALI_TOOL_PREREQ="htslib/1.2.1"
+        #SAMTOOLS earlier then 1 doesn't use htslib
+        #Samtools version 1+ needs matching version htslib (htslib->samtools->bcftools)
+        MINOR_VERSION=$(echo $MAALI_TOOL_VERSION | cut -d . -f 2)
+
+        #echo $MINOR_VERSION
+        if [ "$MINOR_VERSION" == "2" ];
+                then
+                MAALI_TOOL_PREREQ="htslib/1.2.1"
+        else
+                MAALI_TOOL_PREREQ="htslib/1.3"
+        fi
+
 fi
+
+#Variable is needed to SRC HTSLIB_VERSION when you load a HTSLIBRARY
+#1 or earlier has no htslib
+#1.2 uses 1.2 or 1.2.1?
+#1.3 uses 1.3 
+
+PREREQ_HTSLIB_VERSION=`echo $MAALI_HTSLIB_HOME | rev | cut -d "/" -f 1 | rev`
 
 # tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
 MAALI_TOOL_BUILD_PREREQ=""
@@ -51,6 +69,8 @@ function maali_build {
   # fix for SLES11
   sed -i -e 's/lcurses/lncurses/g' Makefile
 
+  cp Makefile Makefile.backup
+
   if [[ $(echo "if (${MAALI_TOOL_MAJOR_VERSION} >= 1) 1 else 0" | bc) -eq 1 ]]; then
       if [ "$MAALI_TOOL_VERSION" != "1.1" ]; then
         # this should already be installed
@@ -62,19 +82,33 @@ function maali_build {
       fi
 
       if [ "$MAALI_TOOL_VERSION" == "1.1" ]; then
+        cp Makefile Makefile.backup
         sed -i -e 's!HTSDIR = ../htslib!HTSDIR = '$MAALI_HTSLIB_HOME'/include!g' Makefile
-        sed -i -e 's!include $(HTSDIR)/htslib.mk!#include $(HTSDIR)/htslib.mk!g' Makefile
-        sed -i -e 's!HTSLIB = $(HTSDIR)/libhts.a!HTSLIB = '$MAALI_HTSLIB_HOME'/lib/libhts.a!g' Makefile
+        #sed -i -e 's!include $(HTSDIR)/htslib.mk!#include $(HTSDIR)/htslib.mk!g' Makefile
+        sed -i -e 's!include $(HTSDIR)/htslib.mk!#include '$MAALI_HTSLIB_HOME'/htslib.mk!g' Makefile
+	sed -i -e 's!HTSLIB = $(HTSDIR)/libhts.a!HTSLIB = '$MAALI_HTSLIB_HOME'/lib/libhts.a!g' Makefile
         sed -i -e 's!BGZIP  = $(HTSDIR)/bgzip!BGZIP  = '$MAALI_HTSLIB_HOME'/bin/bgzip!g' Makefile
-      else
+      elif [ "$MAALI_TOOL_VERSION" == "1.2" ]; then
+        cp Makefile Makefile.backup
         sed -i -e 's!HTSDIR = htslib-1.2.1!HTSDIR = '$MAALI_HTSLIB_HOME'/include!g' Makefile
-        sed -i -e 's!include $(HTSDIR)/htslib.mk!#include $(HTSDIR)/htslib.mk!g' Makefile
+        #sed -i -e 's!include $(HTSDIR)/htslib.mk!#include $(HTSDIR)/htslib.mk!g' Makefile
         sed -i -e 's!HTSLIB = $(HTSDIR)/!HTSLIB = '$MAALI_HTSLIB_HOME'/lib/!g' Makefile
         sed -i -e 's!BGZIP  = $(HTSDIR)/bgzip!BGZIP  = '$MAALI_HTSLIB_HOME'/bin/bgzip!g' Makefile
+      else
+	# As of 1.3 it now has a configure
+	./configure --with-htslib=$MAALI_HTSLIB_HOME
       fi
 
       maali_run "make"
       maali_run "make prefix=$MAALI_INSTALL_DIR install"
+      
+      # as of 1.2 / 1.3 it doesn't copy the libpam.a
+      # Missing Header files
+      mkdir -p ${MAALI_INSTALL_DIR}/lib
+      cp libbam.a ${MAALI_INSTALL_DIR}/lib
+      mkdir -p ${MAALI_INSTALL_DIR}/include/bam
+      cp *.h ${MAALI_INSTALL_DIR}/include/bam	
+
   else
       if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
           sed -i -e 's!gcc!icc!g' Makefile
@@ -99,11 +133,15 @@ function maali_build {
         fi
 
         maali_makedir "$MAALI_INSTALL_DIR/lib"
-        maali_run "mv libbam.a $MAALI_INSTALL_DIR/lib"
+        maali_run "cp libbam.a $MAALI_INSTALL_DIR/lib"
         maali_makedir "$MAALI_INSTALL_DIR/include/bam"
-        maali_run "mv *.h $MAALI_INSTALL_DIR/include/bam"
+        maali_run "cp *.h $MAALI_INSTALL_DIR/include/bam"
     fi
 
+    #Make a copy of tbe Code Base needed for other things like Augusta Auxillary tools which complians
+    #samtools / libhts / bcftools are interlinked badly
+    mkdir -p ${MAALI_INSTALL_DIR}/src
+    cp -R ${MAALI_TOOL_BUILD_DIR}/* ${MAALI_INSTALL_DIR}/src/
 }
 
 ##############################################################################


### PR DESCRIPTION
- Reworked Samtools
  *\* Add 1.3 support
  *\* Add fix for missing headers / libraries for gcc version build
  *\* Add copy of the src build to install area for use later ie Augusta Auxillary tools
  *\* Strip out unnessary hardcoded htslib reference vesions
  **\* Samtools kinda odd it needs to have matching version of htslib / samtools but there are exceptions
- Reworked Augustus
  *\* Fix bam2wig
  *\* Try to use the src code built from samtools
