### PR TITLE
Update memory_profiler.cyg

### DIFF
--- a/cle52up04/memory_profiler.cyg
+++ b/cle52up04/memory_profiler.cyg
@@ -28,10 +28,3 @@ MAALI_MODULE_SET_PATH=1
 MAALI_MODULE_WHATIS="Python memory profiler."
 
 ##############################################################################
-
-function maali_python_build {
-  cd $MAALI_TOOL_BUILD_DIR
-  maali_run "python setup.py install"
-}
-
-##############################################################################


### PR DESCRIPTION
It was trying to install in base python

Removed the function and used the generic python build function
