### PR TITLE
Update healpy.cyg

### DIFF
--- a/cle52up04/healpy.cyg
+++ b/cle52up04/healpy.cyg
@@ -15,21 +15,12 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ="PrgEnv-gnu/5.2.82 gcc/4.8.2 numpy/1.10.1 setuptools/18.4"
+MAALI_TOOL_PREREQ="PrgEnv-gnu/5.2.82 gcc/4.8.2 numpy/1.10.1 setuptools/18.4 astropy/1.1 cython/0.23.4 matplotlib/1.5.0"
 
 # tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
 MAALI_TOOL_BUILD_PREREQ=""
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
-
-##############################################################################
-
-function maali_python_build {
-
-    cd $MAALI_TOOL_BUILD_DIR
-    maali_run "python setup.py install"
-
-}
 
 ##############################################################################


### PR DESCRIPTION
Address issue it installs to base python installation
Used maali generic python install
Address missing dependency ie astropy, cython, matplotlib (Otherwise it attempts the python easy install into base package)
