### PR TITLE
Update h5py.cyg

### DIFF
--- a/cle52up04/h5py.cyg
+++ b/cle52up04/h5py.cyg
@@ -15,7 +15,7 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tgz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ="PrgEnv-gnu/5.2.82 gcc/4.8.2 numpy/1.10.1 cython/0.23.4 pkgconfig/1.1.0 cray-hdf5/1.8.13"
+MAALI_TOOL_PREREQ="PrgEnv-gnu/5.2.82 gcc/4.8.2 numpy/1.10.1 cython/0.23.4 pkgconfig/1.1.0 cray-hdf5/1.8.13 traceback2/1.3.0 linecache2/1.0.0 argparse/1.4.0 six/1.10.0 unittest2/1.1.0"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1


### PR DESCRIPTION
To build the dependency is just this
PrgEnv-gnu/5.2.82 gcc/4.8.2 numpy/1.10.1 cython/0.23.4 pkgconfig/1.1.0 cray-hdf5/1.8.13 

But to actually run it or import it is you need these dependency
traceback2/1.3.0 linecache2/1.0.0 argparse/1.4.0 six/1.10.0 unittest2/1.1.0
